### PR TITLE
Remove non-components from TOC.yml

### DIFF
--- a/creator/Reference/Content/ItemReference/Examples/ItemComponents/TOC.yml
+++ b/creator/Reference/Content/ItemReference/Examples/ItemComponents/TOC.yml
@@ -2,10 +2,6 @@
    href: ../ItemComponentList.md
  - name: Custom Item Use Priority
    href: ../ItemUsePriority.md
- - name: description
-   href: description_component.md
- - name: menu_category
-   href: menu_category_component.md
  - name: allow_off_hand
    href: minecraft_allow_off_hand.md
  - name: block_placer


### PR DESCRIPTION
description and menu_category are not technically item components, so they should not be in this category. They should be documented in ItemDefinition.md

Also, the menu_category page doesn't even exist currently.